### PR TITLE
Bugfix login to player name

### DIFF
--- a/main.js
+++ b/main.js
@@ -62,7 +62,11 @@ function initializePlayer(e){
 }
 
 function setPlayerName(e){
-    playerName.innerText = e.target.value;
+    if (e.target.value) {
+        playerName.innerText = e.target.value;
+        return;
+    } 
+    playerName.innerText = `Player 1`
 }
 
 function changeFighterPaladin(){


### PR DESCRIPTION
Fixed a bug where if input field on login page was left empty, player name would not populate. Now will default to `player 1`